### PR TITLE
fus.rs: Don't treat missing XML text nodes as a missing FUS field

### DIFF
--- a/samfuslib/src/crypto.rs
+++ b/samfuslib/src/crypto.rs
@@ -105,7 +105,7 @@ impl FusAes256 {
         let iv = &padded_key[..16];
 
         let ga_key = GenericArray::from_slice(&padded_key);
-        let ga_iv = GenericArray::from_slice(&iv);
+        let ga_iv = GenericArray::from_slice(iv);
 
         cfg_if::cfg_if! {
             if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
@@ -170,7 +170,7 @@ pub enum FusFileAes128 {
 impl FusFileAes128 {
     /// Create a new cipher instance for decrypting FUS files.
     pub fn new(key: &[u8]) -> Self {
-        let ga_key = GenericArray::from_slice(&key);
+        let ga_key = GenericArray::from_slice(key);
         let ga_iv = &GenericArray::default();
 
         cfg_if::cfg_if! {

--- a/samfuslib/src/fus.rs
+++ b/samfuslib/src/fus.rs
@@ -159,13 +159,13 @@ impl Nonce {
     }
 
     /// Convert nonce to fixed-key-encrypted nonce.
-    pub fn to_encrypted(&self, keys: &FusKeys) -> String {
+    pub fn to_encrypted(self, keys: &FusKeys) -> String {
         base64::encode(FusAes256::new(&keys.fixed_key).encrypt(&self.data))
     }
 
     /// Get the nonce signature to be used in the Authorization header for FUS
     /// requests.
-    fn to_signature(&self, keys: &FusKeys) -> String {
+    fn to_signature(self, keys: &FusKeys) -> String {
         let key = keys.get_flexible_key(self.as_slice());
         let ciphertext = FusAes256::new(&key).encrypt(self.as_slice());
 
@@ -173,13 +173,13 @@ impl Nonce {
     }
 
     /// Get full Authorization header value containing the nonce signature.
-    fn to_authorization(&self, keys: &FusKeys) -> Authorization {
+    fn to_authorization(self, keys: &FusKeys) -> Authorization {
         Authorization::with_signature(&self.to_signature(keys))
     }
 
     /// Get the scrambled nonce value to be used in the <LOGIC_CHECK> XML tag of
     /// FUS requests.
-    fn to_logic_check(&self, lc_type: LogicCheckType) -> String {
+    fn to_logic_check(self, lc_type: LogicCheckType) -> String {
         match lc_type {
             LogicCheckType::Data(data) => {
                 if data.is_empty() {
@@ -521,7 +521,7 @@ impl FusClient {
     ) -> Result<impl Stream<Item = reqwest::Result<Bytes>>, FusError> {
         // It is necessary to inform the service of the intention to download
         let nonce = self.ensure_nonce().await?;
-        let req_root = Self::create_binary_init_elem(&info, nonce);
+        let req_root = Self::create_binary_init_elem(info, nonce);
 
         let url = format!("{}/NF_DownloadBinaryInitForMass.do", FUS_BASE_URL);
         self.execute_fus_xml_request(&url, &req_root, false).await?;

--- a/samfuslib/src/fus.rs
+++ b/samfuslib/src/fus.rs
@@ -647,7 +647,7 @@ impl FusClient {
             result = result.and_then(|e| e.get_child(*p));
         }
 
-        result.and_then(|e| e.get_text())
+        result.map(|e| e.get_text().unwrap_or(Cow::Borrowed("")))
     }
 
     fn get_fus_field<'a>(elem: &'a Element, field: &str) -> Option<Cow<'a, str>> {


### PR DESCRIPTION
`<Data></Data>` should be treated as an empty string instead.

This fixes the downloading of old firmware using the `enc2` scheme.