### PR TITLE
Update base URL for downloads

### DIFF
--- a/samfuslib/src/fus.rs
+++ b/samfuslib/src/fus.rs
@@ -29,7 +29,7 @@ use xmltree::{Element, XMLNode};
 
 const FOTA_BASE_URL: &str = "https://fota-cloud-dn.ospserver.net";
 const FUS_BASE_URL: &str = "https://neofussvr.sslcs.cdngc.net";
-const DOWNLOAD_BASE_URL: &str = "http://cloud-neofussvr.sslcs.cdngc.net";
+const DOWNLOAD_BASE_URL: &str = "https://cloud-neofussvr.samsungmobile.com";
 const NON_UTF8_MSG: &str = "[Non-UTF-8 data]";
 
 fn to_utf8_or_error_string(data: &[u8]) -> &str {


### PR DESCRIPTION
The old URL always returns 403 when requesting a download, even if the nonce is valid. Also, HTTPS now works again with the new URL.